### PR TITLE
Archive orders feature

### DIFF
--- a/includes/class-wc-customer-data-store-custom-table.php
+++ b/includes/class-wc-customer-data-store-custom-table.php
@@ -52,7 +52,7 @@ class WC_Customer_Data_Store_Custom_Table extends WC_Customer_Data_Store {
 				// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
 				"SELECT posts.ID
 				FROM $wpdb->posts AS posts
-				LEFT JOIN {$wpdb->postmeta} AS meta on posts.ID = meta.post_id
+				INNER JOIN {$wpdb->postmeta} AS meta on posts.ID = meta.post_id
 				WHERE meta.meta_key = '_customer_user'
 				AND   meta.meta_value = '" . esc_sql( $customer->get_id() ) . "'
 				AND   posts.post_type = 'shop_order'

--- a/includes/class-wc-customer-data-store-custom-table.php
+++ b/includes/class-wc-customer-data-store-custom-table.php
@@ -20,14 +20,14 @@ class WC_Customer_Data_Store_Custom_Table extends WC_Customer_Data_Store {
 	 * @return WC_Order|false
 	 */
 	public function get_last_order( &$customer ) {
-		// Check postmeta first
+		// Check postmeta first.
 		$last_order = $this->get_last_order_meta( $customer );
 
 		if ( $last_order ) {
 			return $last_order;
 		}
 
-		// $last_order is false, so we look for last_order in archive
+		// $last_order is false, so we look for last_order in archive.
 		return $this->get_last_order_archive( $customer );
 	}
 

--- a/includes/class-wc-customer-data-store-custom-table.php
+++ b/includes/class-wc-customer-data-store-custom-table.php
@@ -13,122 +13,6 @@
 class WC_Customer_Data_Store_Custom_Table extends WC_Customer_Data_Store {
 
 	/**
-	 * Gets the customers last order.
-	 *
-	 * @global $wpdb
-	 *
-	 * @param WC_Customer $customer The WC_Customer object, passed by reference.
-	 *
-	 * @return WC_Order|false The last order from this customer, or FALSE if the customer has not
-	 *                        made an order.
-	 */
-	public function get_last_order( &$customer ) {
-		global $wpdb;
-
-		$table      = wc_custom_order_table()->get_table_name();
-		$statuses   = wc_get_order_statuses();
-		$last_order = $wpdb->get_var(
-			$wpdb->prepare(
-				"
-				SELECT posts.ID FROM $wpdb->posts AS posts
-				LEFT JOIN " . esc_sql( $table ) . " AS meta on posts.ID = meta.order_id
-				WHERE meta.customer_id = %d
-				AND   posts.post_type  = 'shop_order'
-				AND   posts.post_status IN (" . implode( ', ', array_fill( 0, count( $statuses ), '%s' ) ) . ')
-				ORDER BY posts.ID DESC LIMIT 1',
-				array_merge( array( $customer->get_id() ), array_keys( $statuses ) )
-			)
-		);
-
-		return $last_order ? wc_get_order( (int) $last_order ) : false;
-	}
-
-	/**
-	 * Return the number of orders this customer has.
-	 *
-	 * @global $wpdb
-	 *
-	 * @param WC_Customer $customer The WC_Customer object, passed by reference.
-	 *
-	 * @return int The number of orders for this customer.
-	 */
-	public function get_order_count( &$customer ) {
-		global $wpdb;
-
-		$count = get_user_meta( $customer->get_id(), '_order_count', true );
-
-		if ( '' === $count ) {
-			$table    = wc_custom_order_table()->get_table_name();
-			$statuses = wc_get_order_statuses();
-			$count    = $wpdb->get_var(
-				$wpdb->prepare(
-					"
-					SELECT COUNT(*) FROM $wpdb->posts as posts
-					LEFT JOIN " . esc_sql( $table ) . " AS meta ON posts.ID = meta.order_id
-					WHERE meta.customer_id = %d
-					AND   posts.post_type  = 'shop_order'
-					AND   posts.post_status IN (" . implode( ', ', array_fill( 0, count( $statuses ), '%s' ) ) . ')',
-					array_merge( array( $customer->get_id() ), array_keys( $statuses ) )
-				)
-			);
-			update_user_meta( $customer->get_id(), '_order_count', $count );
-		}
-
-		return (int) $count;
-	}
-
-	/**
-	 * Return how much money this customer has spent.
-	 *
-	 * @global $wpdb
-	 *
-	 * @param WC_Customer $customer The WC_Customer object, passed by reference.
-	 *
-	 * @return float The total amount spent by the customer.
-	 */
-	public function get_total_spent( &$customer ) {
-		global $wpdb;
-
-		$spent = get_user_meta( $customer->get_id(), '_money_spent', true );
-
-		/**
-		 * Filter the total amount spent by the given customer across all orders.
-		 *
-		 * @param float $spent The total of all orders for this customer.
-		 * @param WC_Customer $customer The customer being queried.
-		 */
-		$spent = apply_filters( 'woocommerce_customer_get_total_spent', $spent, $customer );
-
-		// If there's no saved value, attempt to calculate one.
-		if ( '' === $spent ) {
-			$table    = wc_custom_order_table()->get_table_name();
-			$statuses = array_map( 'self::prefix_wc_status', wc_get_is_paid_statuses() );
-			$sql      = $wpdb->prepare(
-				"
-				SELECT SUM(meta.total) FROM $wpdb->posts as posts
-				LEFT JOIN " . esc_sql( $table ) . " AS meta ON posts.ID = meta.order_id
-				WHERE   meta.customer_id  = %d
-				AND     posts.post_type   = 'shop_order'
-				AND     posts.post_status IN (" . implode( ', ', array_fill( 0, count( $statuses ), '%s' ) ) . ')',
-				array_merge( array( $customer->get_id() ), $statuses )
-			);
-
-			/**
-			 * Filter the MySQL query used to determine how much a customer has spent across all orders.
-			 *
-			 * @param string      $sql      The prepared MySQL statement.
-			 * @param WC_Customer $customer The customer being queried.
-			 */
-			$sql   = apply_filters( 'woocommerce_customer_get_total_spent_query', $sql, $customer );
-			$spent = (float) $wpdb->get_var( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-
-			update_user_meta( $customer->get_id(), '_money_spent', $spent );
-		}
-
-		return $spent;
-	}
-
-	/**
 	 * Register callbacks when the data store is first instantiated.
 	 */
 	public static function add_hooks() {
@@ -151,7 +35,7 @@ class WC_Customer_Data_Store_Custom_Table extends WC_Customer_Data_Store {
 	 * @param int    $user_id User ID to check.
 	 * @param int    $product_id Product ID to check.
 	 *
-	 * @return bool Whether or not the customer has already purchased the given product ID.
+	 * @return bool|null Whether or not the customer has already purchased the given product ID.
 	 */
 	public static function pre_customer_bought_product( $purchased, $customer_email, $user_id, $product_id ) {
 		global $wpdb;
@@ -178,7 +62,11 @@ class WC_Customer_Data_Store_Custom_Table extends WC_Customer_Data_Store {
 			$statuses      = array_map( 'self::prefix_wc_status', wc_get_is_paid_statuses() );
 
 			if ( 0 === count( $customer_data ) ) {
-				return false;
+				/**
+				 * Instead of returning false, we return null so that the function
+				 * moves on to query the wp_postmeta table for the same.
+				 */
+				return null;
 			}
 
 			$table  = wc_custom_order_table()->get_table_name();

--- a/includes/class-wc-order-data-store-custom-table.php
+++ b/includes/class-wc-order-data-store-custom-table.php
@@ -65,16 +65,16 @@ class WC_Order_Data_Store_Custom_Table extends WC_Order_Data_Store_CPT {
 			 * Removed automatic migration of data to custom table.
 			 * Instead, we try to fetch metadata normally from the table.
 			 */
-			$id = $order->get_id();
+			$id   = $order->get_id();
 			$data = array();
 
-			// Loop over internal postmeta properties
+			// Loop over internal postmeta properties.
 			foreach ( WooCommerce_Custom_Orders_Table::get_postmeta_mapping() as $key => $value ) {
-				$data[$key] = get_post_meta( $id, $value, true );
+				$data[ $key ] = get_post_meta( $id, $value, true );
 			}
 
-			// Get post for additional notes passed by the customer
-			$post = get_post( $id );
+			// Get post for additional notes passed by the customer.
+			$post                  = get_post( $id );
 			$data['customer_note'] = $post->post_excerpt;
 
 			$order->set_props( $data );

--- a/includes/class-wc-order-data-store-custom-table.php
+++ b/includes/class-wc-order-data-store-custom-table.php
@@ -52,9 +52,6 @@ class WC_Order_Data_Store_Custom_Table extends WC_Order_Data_Store_CPT {
 	/**
 	 * Read order data from the custom orders table.
 	 *
-	 * If the order does not yet exist, the plugin will attempt to migrate it automatically. This
-	 * behavior can be modified via the "wc_custom_order_table_automatic_migration" filter.
-	 *
 	 * @param WC_Order $order       The order object, passed by reference.
 	 * @param object   $post_object The post object.
 	 */

--- a/includes/class-wc-order-data-store-custom-table.php
+++ b/includes/class-wc-order-data-store-custom-table.php
@@ -184,6 +184,21 @@ class WC_Order_Data_Store_Custom_Table extends WC_Order_Data_Store_CPT {
 			'prices_include_tax'   => wc_bool_to_string( $order->get_prices_include_tax( 'edit' ) ),
 		);
 
+		// Add additional metakeys data.
+		$extra_metakeys   = get_option( WC_CUSTOM_ORDER_TABLE_OPTION, array() );
+		$extra_order_data = $order->get_meta_data();
+
+		if ( $extra_metakeys ) {
+			// Loop over keys to find the values and add them to $order_data array.
+			foreach ( $extra_order_data as $single_order_data ) {
+				if ( ! in_array( $single_order_data->key, array_keys( $extra_metakeys ), true ) ) {
+					continue;
+				}
+
+				$order_data[ $single_order_data->key ] = $single_order_data->value;
+			}
+		}
+
 		// Convert dates to timestamps, if they exist.
 		foreach ( array( 'date_completed', 'date_paid' ) as $date ) {
 			if ( $order_data[ $date ] instanceof WC_DateTime ) {

--- a/includes/class-wc-order-data-store-custom-table.php
+++ b/includes/class-wc-order-data-store-custom-table.php
@@ -65,16 +65,22 @@ class WC_Order_Data_Store_Custom_Table extends WC_Order_Data_Store_CPT {
 			$order->set_props( $data );
 		} else {
 			/**
-			 * Toggle the ability for WooCommerce Custom Orders Table to automatically migrate orders.
-			 *
-			 * @param bool $migrate Whether or not orders should automatically be migrated once they
-			 *                      have been loaded.
+			 * Removed automatic migration of data to custom table.
+			 * Instead, we try to fetch metadata normally from the table.
 			 */
-			$migrate = apply_filters( 'wc_custom_order_table_automatic_migration', true );
+			$id = $order->get_id();
+			$data = array();
 
-			if ( $migrate ) {
-				$this->populate_from_meta( $order );
+			// Loop over internal postmeta properties
+			foreach ( WooCommerce_Custom_Orders_Table::get_postmeta_mapping() as $key => $value ) {
+				$data[$key] = get_post_meta( $id, $value, true );
 			}
+
+			// Get post for additional notes passed by the customer
+			$post = get_post( $id );
+			$data['customer_note'] = $post->post_excerpt;
+
+			$order->set_props( $data );
 		}
 	}
 

--- a/includes/class-wc-order-refund-data-store-custom-table.php
+++ b/includes/class-wc-order-refund-data-store-custom-table.php
@@ -17,9 +17,6 @@ class WC_Order_Refund_Data_Store_Custom_Table extends WC_Order_Refund_Data_Store
 	/**
 	 * Read refund data from the custom orders table.
 	 *
-	 * If the refund does not yet exist, the plugin will attempt to migrate it automatically. This
-	 * behavior can be modified via the "wc_custom_order_table_automatic_migration" filter.
-	 *
 	 * @param WC_Order_Refund $refund      The refund object, passed by reference.
 	 * @param object          $post_object The post object.
 	 */
@@ -29,12 +26,23 @@ class WC_Order_Refund_Data_Store_Custom_Table extends WC_Order_Refund_Data_Store
 		if ( ! empty( $data ) ) {
 			$refund->set_props( $data );
 		} else {
-			/** This filter is defined in class-wc-order-data-store-custom-table.php. */
-			$migrate = apply_filters( 'wc_custom_order_table_automatic_migration', true );
+			/**
+			 * Removed automatic migration of data to custom table.
+			 * Instead, we try to fetch metadata normally from the table.
+			 */
+			$id = $refund->get_id();
+			$data = array();
 
-			if ( $migrate ) {
-				$this->populate_from_meta( $refund );
+			// Loop over internal postmeta properties
+			foreach ( WooCommerce_Custom_Orders_Table::get_postmeta_mapping() as $key => $value ) {
+				$data[$key] = get_post_meta( $id, $value, true );
 			}
+
+			// Get post for additional notes passed by the customer
+			$post = get_post( $id );
+			$data['customer_note'] = $post->post_excerpt;
+
+			$refund->set_props( $data );
 		}
 	}
 

--- a/includes/class-wc-order-refund-data-store-custom-table.php
+++ b/includes/class-wc-order-refund-data-store-custom-table.php
@@ -102,6 +102,21 @@ class WC_Order_Refund_Data_Store_Custom_Table extends WC_Order_Refund_Data_Store
 			'refunded_by'        => $refund->get_refunded_by( 'edit' ),
 		);
 
+		// Add additional metakeys data.
+		$extra_metakeys    = get_option( WC_CUSTOM_ORDER_TABLE_OPTION, array() );
+		$extra_refund_data = $refund->get_meta_data();
+
+		if ( $extra_metakeys ) {
+			// Loop over keys to find the values and add them to $refund_data array.
+			foreach ( $extra_refund_data as $single_refund_data ) {
+				if ( ! in_array( $single_refund_data->key, array_keys( $extra_metakeys ), true ) ) {
+					continue;
+				}
+
+				$order_data[ $single_refund_data->key ] = $single_refund_data->value;
+			}
+		}
+
 		// Insert or update the database record.
 		if ( ! wc_custom_order_table()->row_exists( $refund_data['order_id'] ) ) {
 			$inserted = $wpdb->insert( $table, $refund_data ); // WPCS: DB call OK.

--- a/includes/class-wc-order-refund-data-store-custom-table.php
+++ b/includes/class-wc-order-refund-data-store-custom-table.php
@@ -30,16 +30,16 @@ class WC_Order_Refund_Data_Store_Custom_Table extends WC_Order_Refund_Data_Store
 			 * Removed automatic migration of data to custom table.
 			 * Instead, we try to fetch metadata normally from the table.
 			 */
-			$id = $refund->get_id();
+			$id   = $refund->get_id();
 			$data = array();
 
-			// Loop over internal postmeta properties
+			// Loop over internal postmeta properties.
 			foreach ( WooCommerce_Custom_Orders_Table::get_postmeta_mapping() as $key => $value ) {
-				$data[$key] = get_post_meta( $id, $value, true );
+				$data[ $key ] = get_post_meta( $id, $value, true );
 			}
 
-			// Get post for additional notes passed by the customer
-			$post = get_post( $id );
+			// Get post for additional notes passed by the customer.
+			$post                  = get_post( $id );
 			$data['customer_note'] = $post->post_excerpt;
 
 			$refund->set_props( $data );

--- a/includes/class-woocommerce-custom-orders-table-cli.php
+++ b/includes/class-woocommerce-custom-orders-table-cli.php
@@ -330,6 +330,8 @@ class WooCommerce_Custom_Orders_Table_CLI extends WP_CLI_Command {
 
 	/**
 	 * Build a SQL query to get posts that require migration.
+	 * Orders not marked as "completed" or the ones less than 7 days old
+	 * are skipped from migration.
 	 *
 	 * @global $wpdb
 	 *
@@ -350,6 +352,8 @@ class WooCommerce_Custom_Orders_Table_CLI extends WP_CLI_Command {
 			FROM {$wpdb->posts} p
 			LEFT JOIN {$order_table} o ON p.ID = o.order_id
 			WHERE p.post_type IN (" . implode( ', ', array_fill( 0, count( $order_types ), '%s' ) ) . ')
+			AND p.post_status = "wc-completed"
+			AND p.post_modified >= DATE_SUB(SYSDATE(), INTERVAL 7 DAY)
 			AND o.order_id IS NULL
 		';
 		$parameters  = $order_types;

--- a/includes/class-woocommerce-custom-orders-table-cli.php
+++ b/includes/class-woocommerce-custom-orders-table-cli.php
@@ -163,6 +163,7 @@ class WooCommerce_Custom_Orders_Table_CLI extends WP_CLI_Command {
 	public function populate() {
 		global $wpdb;
 
+		$cols_added    = 0;
 		$metakeys_list = get_option( $this->option_name );
 
 		if ( ! $metakeys_list ) {
@@ -186,7 +187,11 @@ class WooCommerce_Custom_Orders_Table_CLI extends WP_CLI_Command {
 			// Column already exists.
 			if ( $column ) {
 				WP_CLI::log(
-					$col_name . esc_html__( ' column already exists in the database.', 'woocommerce-custom-orders-table' )
+					sprintf(
+						/* translators: %s: column name */
+						esc_html__( '`%s` column already exists in the database.', 'woocommerce-custom-orders-table' ),
+						$col_name
+					)
 				);
 
 				continue;
@@ -202,10 +207,27 @@ class WooCommerce_Custom_Orders_Table_CLI extends WP_CLI_Command {
 
 			if ( ! $query ) {
 				WP_CLI::error(
-					esc_html__( 'There was an error while adding column to the table.', 'woocommerce-custom-orders-table' )
+					sprintf(
+						/* translators: %s: column name */
+						esc_html__( 'There was an error while adding `%s` column to the table.', 'woocommerce-custom-orders-table' ),
+						$col_name
+					)
 				);
+
+				continue;
 			}
+
+			++$cols_added;
 		}
+
+		// Add a message at the end.
+		WP_CLI::success(
+			sprintf(
+				/* translators: %s: column name */
+				esc_html__( '%s columns added to the table.', 'woocommerce-custom-orders-table' ),
+				$cols_added
+			)
+		);
 	}
 
 	/**

--- a/includes/class-woocommerce-custom-orders-table.php
+++ b/includes/class-woocommerce-custom-orders-table.php
@@ -93,7 +93,7 @@ class WooCommerce_Custom_Orders_Table {
 	 * @return array An array of database columns and their corresponding post_meta keys.
 	 */
 	public static function get_postmeta_mapping() {
-		return array(
+		$metakeys = array(
 			'order_key'            => '_order_key',
 			'customer_id'          => '_customer_user',
 			'payment_method'       => '_payment_method',
@@ -145,6 +145,24 @@ class WooCommerce_Custom_Orders_Table {
 			'reason'               => '_refund_reason',
 			'refunded_by'          => '_refunded_by',
 		);
+
+		// Get additional meta keys from the database.
+		$extra_metakeys = get_option( WC_CUSTOM_ORDER_TABLE_OPTION, array() );
+
+		if ( ! $extra_metakeys ) {
+			return $metakeys;
+		}
+
+		// Add additional meta keys for migration.
+		foreach ( $extra_metakeys as $meta_key => $col_length ) {
+			if ( isset( $metakeys[ $meta_key ] ) ) {
+				continue;
+			}
+
+			$metakeys[ $meta_key ] = $meta_key;
+		}
+
+		return $metakeys;
 	}
 
 	/**

--- a/includes/class-woocommerce-custom-orders-table.php
+++ b/includes/class-woocommerce-custom-orders-table.php
@@ -281,4 +281,16 @@ class WooCommerce_Custom_Orders_Table {
 	public static function order_refund_data_store() {
 		return 'WC_Order_Refund_Data_Store_Custom_Table';
 	}
+
+	/**
+	 * List of keys which are not required to be migrated.
+	 *
+	 * @return array List of blacklisted keys.
+	 */
+	public static function get_blacklisted_keys() : array {
+		return array(
+			'_edit_lock',
+			'_edit_last'
+		);
+	}
 }

--- a/includes/class-woocommerce-custom-orders-table.php
+++ b/includes/class-woocommerce-custom-orders-table.php
@@ -287,10 +287,10 @@ class WooCommerce_Custom_Orders_Table {
 	 *
 	 * @return array List of blacklisted keys.
 	 */
-	public static function get_blacklisted_keys() : array {
+	public static function get_blacklisted_keys() {
 		return array(
 			'_edit_lock',
-			'_edit_last'
+			'_edit_last',
 		);
 	}
 }

--- a/woocommerce-custom-orders-table.php
+++ b/woocommerce-custom-orders-table.php
@@ -22,6 +22,9 @@ defined( 'ABSPATH' ) || exit;
 define( 'WC_CUSTOM_ORDER_TABLE_URL', plugin_dir_url( __FILE__ ) );
 define( 'WC_CUSTOM_ORDER_TABLE_PATH', plugin_dir_path( __FILE__ ) );
 
+// Database option name.
+define( 'WC_CUSTOM_ORDER_TABLE_OPTION', 'wc_woocart_archive_metakeys' );
+
 /**
  * Autoloader for plugin files.
  *

--- a/woocommerce-custom-orders-table.php
+++ b/woocommerce-custom-orders-table.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Plugin Name:          WooCommerce Custom Orders Table
- * Plugin URI:           https://github.com/liquidweb/woocommerce-custom-orders-tables
- * Description:          Store WooCommerce order data in a custom table for improved performance.
- * Version:              1.0.0-rc3
- * Author:               Liquid Web
- * Author URI:           https://www.liquidweb.com
+ * Plugin Name:          WooCommerce Archive Orders Table
+ * Plugin URI:           https://github.com/woocart/woocommerce-archive-orders-tables
+ * Description:          Archive WooCommerce order data in a custom table for improved performance.
+ * Version:              1.0.0
+ * Author:               WooCart
+ * Author URI:           https://www.woocart.com
  * License:              GPLv3 or later
  * License URI:          https://www.gnu.org/licenses/gpl-3.0.html
  *


### PR DESCRIPTION
Refs https://github.com/niteoweb/woocart/issues/1897

This PR implements archiving of completed orders for WooCommerces into a separate table.

Changes made:

- Orders older than 30 days and with status `wc-completed` can be archived.
- Automatic migration of the orders has been removed.
- Added two CLI commands - `optimize` and `populate`

`optimize` is for finding additional meta keys for the orders and also the largest value of the key. This searches the latest 100 orders for getting this data. This data is then stored in the database as `wc_woocart_archive_metakeys` option.

`populate` is for adding additional columns to the database for storing the meta keys.

**To-do**

- [x] Archive only completed order
- [x] Stop automatic adding of orders to the archive table
- [x] Add a method to detect all additional plugin meta keys and add columns for them
- [x] Test on blogs with orders > 10k

Created a test store with data from `Testogen` which at the time of testing had 62k orders. The test worked fine and all metadata was getting copied. Though it ran into Infinite loop issue which needs to be resolved.