### PR TITLE
Fixes & Improvements

### DIFF
--- a/includes/class-wc-order-data-store-custom-table.php
+++ b/includes/class-wc-order-data-store-custom-table.php
@@ -191,7 +191,7 @@ class WC_Order_Data_Store_Custom_Table extends WC_Order_Data_Store_CPT {
 		if ( $extra_metakeys ) {
 			// Loop over keys to find the values and add them to $order_data array.
 			foreach ( $extra_order_data as $single_order_data ) {
-				if ( ! in_array( $single_order_data->key, array_keys( $extra_metakeys ), true ) ) {
+				if ( ! in_array( $single_order_data->key, $extra_metakeys, true ) ) {
 					continue;
 				}
 

--- a/includes/class-wc-order-refund-data-store-custom-table.php
+++ b/includes/class-wc-order-refund-data-store-custom-table.php
@@ -109,7 +109,7 @@ class WC_Order_Refund_Data_Store_Custom_Table extends WC_Order_Refund_Data_Store
 		if ( $extra_metakeys ) {
 			// Loop over keys to find the values and add them to $refund_data array.
 			foreach ( $extra_refund_data as $single_refund_data ) {
-				if ( ! in_array( $single_refund_data->key, array_keys( $extra_metakeys ), true ) ) {
+				if ( ! in_array( $single_refund_data->key, $extra_metakeys, true ) ) {
 					continue;
 				}
 

--- a/includes/class-woocommerce-custom-orders-table.php
+++ b/includes/class-woocommerce-custom-orders-table.php
@@ -154,7 +154,7 @@ class WooCommerce_Custom_Orders_Table {
 		}
 
 		// Add additional meta keys for migration.
-		foreach ( $extra_metakeys as $meta_key => $col_length ) {
+		foreach ( $extra_metakeys as $meta_key ) {
 			if ( isset( $metakeys[ $meta_key ] ) ) {
 				continue;
 			}


### PR DESCRIPTION
In this PR, the following changes are made:

- Fixed the migration query to include other order statuses and also the part where it was wrongly selecting orders within 30 days instead of orders older than that.
- Improved the `optimize` command to fetch DISTINCT `meta_keys` instead of looping over each order and meta_key to get the max_length.