### PR TITLE
CLI count add $args to enable $assoc_args

### DIFF
--- a/includes/class-woocommerce-custom-orders-table-cli.php
+++ b/includes/class-woocommerce-custom-orders-table-cli.php
@@ -48,10 +48,11 @@ class WooCommerce_Custom_Orders_Table_CLI extends WP_CLI_Command {
 
 	 * @global $wpdb
 	 *
+	 * @param array $args       Positional arguments passed to the command.
 	 * @param array $assoc_args Associative arguments (options) passed to the command.
 	 * @return int The number of orders to be migrated.
 	 */
-	public function count( $assoc_args = array() ) {
+	public function count( $args = array(), $assoc_args = array() ) {
 		global $wpdb;
 
 		$assoc_args = wp_parse_args(


### PR DESCRIPTION
Hi,

Without the param $args in WooCommerce_Custom_Orders_Table_CLI count the function can't retrieve the arguments duration.